### PR TITLE
Debounce switch reconfiguration

### DIFF
--- a/cmd/metalcore/create.go
+++ b/cmd/metalcore/create.go
@@ -2,6 +2,9 @@ package metalcore
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 	"github.com/kelseyhightower/envconfig"
@@ -16,8 +19,6 @@ import (
 	"github.com/metal-stack/metal-lib/zapup"
 	"github.com/metal-stack/v"
 	"go.uber.org/zap"
-	"os"
-	"strings"
 )
 
 func Create() *Server {
@@ -95,21 +96,7 @@ func Create() *Server {
 		os.Exit(1)
 	}
 
-	host, err := os.Hostname()
-	if err != nil {
-		zapup.MustRootLogger().Fatal("failed to detect hostname",
-			zap.Error(err),
-		)
-		os.Exit(1)
-	}
-	err = app.EventHandler().ReconfigureSwitch(host)
-	if err != nil {
-		zapup.MustRootLogger().Fatal("failed to fetch and apply current switch configuration",
-			zap.Error(err),
-		)
-		os.Exit(1)
-	}
-
+	app.initSwitchReconfiguration()
 	app.APIClient().ConstantlyPhoneHome()
 
 	app.BootConfig = &domain.BootConfig{

--- a/internal/core/run.go
+++ b/internal/core/run.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
+
+	httppprof "net/http/pprof"
 
 	"github.com/emicklei/go-restful"
 	"github.com/metal-stack/metal-core/internal/endpoint"
 	"github.com/metal-stack/metal-lib/zapup"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	httppprof "net/http/pprof"
 
 	"go.uber.org/zap"
 )
@@ -19,18 +19,6 @@ func (s *coreServer) Run() {
 	s.initMetrics()
 
 	Init(endpoint.NewHandler(s.AppContext))
-	t := time.NewTicker(s.AppContext.Config.ReconfigureSwitchInterval)
-	host, _ := os.Hostname()
-	go func() {
-		for range t.C {
-			zapup.MustRootLogger().Info("start periodic switch configuration update")
-			err := s.EventHandler().ReconfigureSwitch(host)
-			if err != nil {
-				zapup.MustRootLogger().Error("unable to fetch and apply switch configuration periodically",
-					zap.Error(err))
-			}
-		}
-	}()
 
 	// enable CORS for the UI to work
 	cors := restful.CrossOriginResourceSharing{

--- a/internal/event/handler.go
+++ b/internal/event/handler.go
@@ -25,5 +25,5 @@ func newSwitchReconfigureEvent(switchName, eventType string) switchReconfigureEv
 }
 
 func NewHandler(ctx *domain.AppContext) domain.EventHandler {
-	return &eventHandler{ctx, make(chan switchReconfigureEvent, 50)}
+	return &eventHandler{ctx, make(chan switchReconfigureEvent)}
 }

--- a/internal/event/handler.go
+++ b/internal/event/handler.go
@@ -1,11 +1,29 @@
 package event
 
-import "github.com/metal-stack/metal-core/pkg/domain"
+import (
+	"time"
+
+	"github.com/metal-stack/metal-core/pkg/domain"
+)
 
 type eventHandler struct {
 	*domain.AppContext
+	sr chan switchReconfigureEvent
+}
+type switchReconfigureEvent struct {
+	switchName string
+	eventType  string
+	occurence  time.Time
+}
+
+func newSwitchReconfigureEvent(switchName, eventType string) switchReconfigureEvent {
+	return switchReconfigureEvent{
+		switchName: switchName,
+		eventType:  eventType,
+		occurence:  time.Now(),
+	}
 }
 
 func NewHandler(ctx *domain.AppContext) domain.EventHandler {
-	return &eventHandler{ctx}
+	return &eventHandler{ctx, make(chan switchReconfigureEvent, 50)}
 }

--- a/internal/event/reconfigureSwitch.go
+++ b/internal/event/reconfigureSwitch.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
+	"time"
 
 	sw "github.com/metal-stack/metal-core/client/switch_operations"
 	"github.com/metal-stack/metal-core/internal/switcher"
@@ -16,6 +16,70 @@ import (
 	"github.com/vishvananda/netlink"
 	"go.uber.org/zap"
 )
+
+// TriggerSwitchReconfigure triggers a switch reconfiguration
+func (h *eventHandler) TriggerSwitchReconfigure(switchName, eventType string) {
+	e := newSwitchReconfigureEvent(switchName, eventType)
+	h.sr <- e
+}
+
+// ConsumeSwitchReconfigureEvents consumes the messages on the switch reconfiguration channel and debounces events
+func (h *eventHandler) ConsumeSwitchReconfigureEvents() {
+
+consumeEvents:
+	for {
+		sre := <-h.sr
+		zapup.MustRootLogger().Info("consuming event", zap.Any("sre", sre))
+		err := h.reconfigureSwitch(sre.switchName)q
+		if err != nil {
+			zapup.MustRootLogger().Error("failed to reconfigure switch", zap.Any("sre", sre), zap.Error(err))
+			// notice: there is no continue here - otherwise we would get a mass of errors in case of a failed reconfiguration
+		}
+
+		// skip incoming events at sr channel for the next seconds
+		t := time.NewTimer(h.Config.ReconfigureSwitchInterval)
+		for {
+			select {
+			case sre = <-h.sr: // skip events
+				zapup.MustRootLogger().Info("skip event", zap.Any("sre", sre))
+			case <-t.C:
+				continue consumeEvents
+			}
+		}
+	}
+}
+
+func (h *eventHandler) reconfigureSwitch(switchName string) error {
+	params := sw.NewFindSwitchParams()
+	params.ID = switchName
+	fsr, err := h.SwitchClient.FindSwitch(params, h.Auth)
+	if err != nil {
+		return errors.Wrap(err, "could not fetch switch from metal-api")
+	}
+
+	s := fsr.Payload
+	c, err := buildSwitcherConfig(h.Config, s)
+	if err != nil {
+		return errors.Wrap(err, "could not build switcher config")
+	}
+
+	err = fillEth0Info(c, h.Config.ManagementGateway, h.DevMode)
+	if err != nil {
+		return errors.Wrap(err, "could not gather information about eth0 nic")
+	}
+
+	zapup.MustRootLogger().Info("Assembled new config for switch",
+		zap.Any("config", c))
+	if !h.Config.ReconfigureSwitch {
+		zapup.MustRootLogger().Debug("Skip config application because of environment setting")
+		return nil
+	}
+	err = c.Apply()
+	if err != nil {
+		return errors.Wrap(err, "could not apply switch config")
+	}
+	return nil
+}
 
 func buildSwitcherConfig(conf *domain.Config, s *models.V1SwitchResponse) (*switcher.Conf, error) {
 	c := &switcher.Conf{}
@@ -108,42 +172,6 @@ func mapLogLevel(level string) string {
 	default:
 		return "warnings"
 	}
-}
-
-var mux sync.Mutex
-
-func (h *eventHandler) ReconfigureSwitch(switchID string) error {
-	mux.Lock()
-	defer mux.Unlock()
-	params := sw.NewFindSwitchParams()
-	params.ID = switchID
-	fsr, err := h.SwitchClient.FindSwitch(params, h.Auth)
-	if err != nil {
-		return errors.Wrap(err, "could not fetch switch from metal-api")
-	}
-
-	s := fsr.Payload
-	c, err := buildSwitcherConfig(h.Config, s)
-	if err != nil {
-		return errors.Wrap(err, "could not build switcher config")
-	}
-
-	err = fillEth0Info(c, h.Config.ManagementGateway, h.DevMode)
-	if err != nil {
-		return errors.Wrap(err, "could not gather information about eth0 nic")
-	}
-
-	zapup.MustRootLogger().Info("Assembled new config for switch",
-		zap.Any("config", c))
-	if !h.Config.ReconfigureSwitch {
-		zapup.MustRootLogger().Debug("Skip config application because of environment setting")
-		return nil
-	}
-	err = c.Apply()
-	if err != nil {
-		return errors.Wrap(err, "could not apply switch config")
-	}
-	return nil
 }
 
 func fillEth0Info(c *switcher.Conf, gw string, devMode bool) error {

--- a/pkg/domain/model.go
+++ b/pkg/domain/model.go
@@ -116,8 +116,6 @@ type Config struct {
 	MQLogLevel                string        `required:"false" default:"info" desc:"sets the MQ loglevel (debug, info, warn, error)" envconfig:"mq_loglevel"`
 	MachineTopic              string        `required:"false" default:"machine" desc:"set the machine topic name" split_words:"true"`
 	MachineTopicTTL           int           `required:"false" default:"30000" desc:"sets the TTL in milliseconds for MachineTopic" envconfig:"machine_topic_ttl"`
-	SwitchTopic               string        `required:"false" default:"switch" desc:"set the switch topic name" split_words:"true"`
-	SwitchTopicTTL            int           `required:"false" default:"30000" desc:"sets the TTL in milliseconds for SwitchTopic" envconfig:"switch_topic_ttl"`
 	LoopbackIP                string        `required:"false" default:"10.0.0.11" desc:"set the loopback ip address that is used with BGP unnumbered" split_words:"true"`
 	ASN                       string        `required:"false" default:"420000011" desc:"set the ASN that is used with BGP"`
 	SpineUplinks              string        `required:"false" default:"swp31,swp32" desc:"set the ports that are connected to spines" split_words:"true"`

--- a/pkg/domain/model.go
+++ b/pkg/domain/model.go
@@ -91,7 +91,8 @@ type EventHandler interface {
 	PowerOnChassisIdentifyLED(machineID, description string)
 	PowerOffChassisIdentifyLED(machineID, description string)
 
-	ReconfigureSwitch(switchID string) error
+	TriggerSwitchReconfigure(switchName, eventType string)
+	ConsumeSwitchReconfigureEvents()
 }
 
 type Config struct {

--- a/pkg/domain/model.go
+++ b/pkg/domain/model.go
@@ -116,6 +116,8 @@ type Config struct {
 	MQLogLevel                string        `required:"false" default:"info" desc:"sets the MQ loglevel (debug, info, warn, error)" envconfig:"mq_loglevel"`
 	MachineTopic              string        `required:"false" default:"machine" desc:"set the machine topic name" split_words:"true"`
 	MachineTopicTTL           int           `required:"false" default:"30000" desc:"sets the TTL in milliseconds for MachineTopic" envconfig:"machine_topic_ttl"`
+	SwitchTopic               string        `required:"false" default:"switch" desc:"set the switch topic name" split_words:"true"`
+	SwitchTopicTTL            int           `required:"false" default:"30000" desc:"sets the TTL in milliseconds for SwitchTopic" envconfig:"switch_topic_ttl"`
 	LoopbackIP                string        `required:"false" default:"10.0.0.11" desc:"set the loopback ip address that is used with BGP unnumbered" split_words:"true"`
 	ASN                       string        `required:"false" default:"420000011" desc:"set the ASN that is used with BGP"`
 	SpineUplinks              string        `required:"false" default:"swp31,swp32" desc:"set the ports that are connected to spines" split_words:"true"`

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -46,9 +46,9 @@ func (h *noopEventHandler) PowerOnChassisIdentifyLED(machineID, description stri
 
 func (h *noopEventHandler) PowerOffChassisIdentifyLED(machineID, description string) {}
 
-func (h *noopEventHandler) ReconfigureSwitch(switchID string) error {
-	return nil
-}
+func (h *noopEventHandler) TriggerSwitchReconfigure(switchName, eventType string) {}
+
+func (h *noopEventHandler) ConsumeSwitchReconfigureEvents() {}
 
 func mockAPIEndpoint(apiClient func(ctx *domain.AppContext) domain.APIClient) domain.EndpointHandler {
 	_ = os.Setenv(zapup.KeyLogLevel, "info")


### PR DESCRIPTION
As of now we triggered switch reconfiguration at several places of the metal-core.

This PR streamlines the invocations so that
* a buffered channel is used as a synchronization method instead of a mutex
* events are send to this channel periodically
* events coming from NSQ are passed also to this channel
* debouncing happens by consuming events after processing a single event

/cc @kolsa @ulrichSchreiner @Gerrit91