### PR TITLE
Fix test errors with golang 1.14

### DIFF
--- a/internal/switcher/frr_tpl.go
+++ b/internal/switcher/frr_tpl.go
@@ -104,7 +104,7 @@ router bgp {{ $ASN }} vrf {{ $vrf }}
  address-family ipv4 unicast
   redistribute connected
   neighbor MACHINE maximum-prefix 24000
-  {{- if (len $t.IPPrefixLists) gt 0 }}
+  {{- if gt (len $t.IPPrefixLists) 0 }}
   neighbor MACHINE route-map {{ $vrf }}-in in
   {{- end }}
  exit-address-family
@@ -113,7 +113,7 @@ router bgp {{ $ASN }} vrf {{ $vrf }}
   advertise ipv4 unicast
  exit-address-family
 !
-{{- if (len $t.IPPrefixLists) gt 0 }}
+{{- if gt (len $t.IPPrefixLists) 0 }}
 # route-maps for {{ $vrf }}
         {{- range $t.IPPrefixLists }}
 ip prefix-list {{ .Name }} {{ .Spec }}

--- a/internal/switcher/test_data/customtpl/frr.tpl
+++ b/internal/switcher/test_data/customtpl/frr.tpl
@@ -103,7 +103,7 @@ router bgp {{ $ASN }} vrf {{ $vrf }}
  address-family ipv4 unicast
   redistribute connected
   neighbor MACHINE maximum-prefix 24000
-  {{- if (len $t.IPPrefixLists) gt 0 }}
+  {{- if gt (len $t.IPPrefixLists) 0 }}
   neighbor MACHINE route-map {{ $vrf }}-in in
   {{- end }}
  exit-address-family
@@ -112,7 +112,7 @@ router bgp {{ $ASN }} vrf {{ $vrf }}
   advertise ipv4 unicast
  exit-address-family
 !
-{{- if (len $t.IPPrefixLists) gt 0 }}
+{{- if gt (len $t.IPPrefixLists) 0 }}
 # route-maps for {{ $vrf }}
         {{- range $t.IPPrefixLists }}
 ip prefix-list {{ .Name }} {{ .Spec }}


### PR DESCRIPTION
the template function gt does not support infix notation any longer with golang >= 1.14