### PR TITLE
Don't buffer phoned home events.

### DIFF
--- a/internal/api/event.go
+++ b/internal/api/event.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"time"
+
 	"github.com/metal-stack/metal-core/internal/lldp"
 	"github.com/metal-stack/metal-core/pkg/domain"
 	"github.com/metal-stack/metal-go/api/client/machine"
@@ -16,6 +18,7 @@ func (c *apiClient) AddProvisioningEvent(machineID string, event *models.V1Machi
 	params := machine.NewAddProvisioningEventParams()
 	params.ID = machineID
 	params.Body = event
+	params.WithTimeout(5 * time.Second)
 	_, err := c.MachineClient.AddProvisioningEvent(params, c.Auth)
 	if err != nil {
 		zapup.MustRootLogger().Error("Unable to send provisioning event back to API",

--- a/internal/api/phoneHome.go
+++ b/internal/api/phoneHome.go
@@ -72,7 +72,7 @@ func (c *apiClient) ConstantlyPhoneHome() {
 				mtx.Unlock()
 
 				if sendToAPI {
-					c.PhoneHome(msg)
+					go c.PhoneHome(msg)
 				}
 			}
 		}()

--- a/internal/api/phoneHome.go
+++ b/internal/api/phoneHome.go
@@ -1,14 +1,20 @@
 package api
 
 import (
-	"github.com/google/gopacket/pcap"
-	"github.com/metal-stack/metal-core/internal/lldp"
-	"github.com/metal-stack/metal-lib/zapup"
-	"go.uber.org/zap"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/gopacket/pcap"
+	"github.com/metal-stack/metal-core/internal/lldp"
+	"github.com/metal-stack/metal-lib/zapup"
+	"go.uber.org/zap"
+)
+
+const (
+	InitialPhonedHomeBackoff = 20 * time.Second
+	PhonedHomeBackoff        = 58 * time.Second // lldpd sends messages every two seconds
 )
 
 // ConstantlyPhoneHome sends every minute a single phone-home
@@ -25,8 +31,8 @@ func (c *apiClient) ConstantlyPhoneHome() {
 	}
 
 	frameFragmentChan := make(chan lldp.FrameFragment)
-	m := make(map[string]*lldp.PhoneHomeMessage)
-	mtx := new(sync.RWMutex)
+	m := make(map[string]time.Time)
+	mtx := new(sync.Mutex)
 
 	for _, iface := range ifs {
 		// consider only switch port interfaces
@@ -46,44 +52,29 @@ func (c *apiClient) ConstantlyPhoneHome() {
 		go lldpcli.CatchPackages(frameFragmentChan)
 
 		// extract phone home messages from fetched LLDP packages after a short initial delay
-		time.AfterFunc(50*time.Second, func() {
+		go func() {
+			time.Sleep(InitialPhonedHomeBackoff)
+
 			for phoneHome := range frameFragmentChan {
 				msg := lldpcli.ExtractPhoneHomeMessage(&phoneHome)
 				if msg == nil {
 					continue
 				}
 
-				mtx.RLock()
-				_, ok := m[msg.MachineID]
-				mtx.RUnlock()
-				if !ok {
-					mtx.Lock()
-					m[msg.MachineID] = msg
-					mtx.Unlock()
-					// send first incoming phone home message per machine immediately
+				sendToAPI := false
+
+				mtx.Lock()
+				lastSend, ok := m[msg.MachineID]
+				if !ok || time.Since(lastSend) > PhonedHomeBackoff {
+					sendToAPI = true
+					m[msg.MachineID] = time.Now()
+				}
+				mtx.Unlock()
+
+				if sendToAPI {
 					c.PhoneHome(msg)
 				}
 			}
-		})
+		}()
 	}
-
-	// send phone home messages for each reported-back machine to metal-api every minute
-	t := time.NewTicker(1 * time.Minute)
-	go func() {
-		for range t.C {
-			// buffer phone home messages from map and clear it
-			mtx.Lock()
-			var mm []*lldp.PhoneHomeMessage
-			for machineID, msg := range m {
-				mm = append(mm, msg)
-				delete(m, machineID)
-			}
-			mtx.Unlock()
-
-			// send buffered phone home messages
-			for _, msg := range mm {
-				c.PhoneHome(msg)
-			}
-		}
-	}()
 }

--- a/internal/lldp/client.go
+++ b/internal/lldp/client.go
@@ -2,15 +2,16 @@ package lldp
 
 import (
 	"fmt"
+	"net"
+	"strings"
+	"time"
+
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
 	"github.com/metal-stack/metal-lib/zapup"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	"net"
-	"strings"
-	"time"
 )
 
 const lldpProtocol = "0x88cc"
@@ -30,8 +31,9 @@ type FrameFragment struct {
 
 // PhoneHomeMessage contains a phone-home message.
 type PhoneHomeMessage struct {
-	MachineID string
-	Payload   string
+	MachineID  string
+	Payload    string
+	ReceivedAt time.Time
 }
 
 // NewClient creates a new LLDP client.
@@ -104,8 +106,9 @@ func (l *Client) Close() {
 func (l *Client) ExtractPhoneHomeMessage(frameFragment *FrameFragment) *PhoneHomeMessage {
 	if strings.Contains(frameFragment.SysDescription, "provisioned") {
 		return &PhoneHomeMessage{
-			MachineID: frameFragment.SysName,
-			Payload:   frameFragment.SysDescription,
+			MachineID:  frameFragment.SysName,
+			Payload:    frameFragment.SysDescription,
+			ReceivedAt: time.Now(),
 		}
 	}
 

--- a/internal/lldp/client.go
+++ b/internal/lldp/client.go
@@ -31,9 +31,8 @@ type FrameFragment struct {
 
 // PhoneHomeMessage contains a phone-home message.
 type PhoneHomeMessage struct {
-	MachineID  string
-	Payload    string
-	ReceivedAt time.Time
+	MachineID string
+	Payload   string
 }
 
 // NewClient creates a new LLDP client.
@@ -106,9 +105,8 @@ func (l *Client) Close() {
 func (l *Client) ExtractPhoneHomeMessage(frameFragment *FrameFragment) *PhoneHomeMessage {
 	if strings.Contains(frameFragment.SysDescription, "provisioned") {
 		return &PhoneHomeMessage{
-			MachineID:  frameFragment.SysName,
-			Payload:    frameFragment.SysDescription,
-			ReceivedAt: time.Now(),
+			MachineID: frameFragment.SysName,
+			Payload:   frameFragment.SysDescription,
 		}
 	}
 


### PR DESCRIPTION
This approach sends away incoming LLDP messages directly after a backoff. This eliminates phoned home events arriving somewhat late. Described in more detail at https://github.com/metal-stack/metal-api/pull/167#issuecomment-774982009.

Also distributes event requests over time, which is easier to handle for the metal-api.

Also less complex I guess.