### PR TITLE
Remove sequence numbers from prefix lists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.16
 require (
 	github.com/emicklei/go-restful-openapi/v2 v2.3.0
 	github.com/emicklei/go-restful/v3 v3.5.1
-	github.com/go-openapi/errors v0.20.0
+	github.com/go-openapi/errors v0.20.0 // indirect
 	github.com/go-openapi/runtime v0.19.28
 	github.com/go-openapi/spec v0.20.3
 	github.com/go-openapi/strfmt v0.20.1
-	github.com/go-openapi/swag v0.19.15
-	github.com/go-openapi/validate v0.20.2
+	github.com/go-openapi/swag v0.19.15 // indirect
+	github.com/go-openapi/validate v0.20.2 // indirect
 	github.com/google/gopacket v1.1.19
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/metal-stack/go-hal v0.3.4

--- a/internal/event/reconfigureSwitch_test.go
+++ b/internal/event/reconfigureSwitch_test.go
@@ -70,7 +70,7 @@ func TestBuildSwitcherConfig(t *testing.T) {
 					IPPrefixLists: []switcher.IPPrefixList{
 						{
 							Name: "vrf104001-in-prefixes",
-							Spec: "seq 10 permit 10.244.0.0/16 le 32",
+							Spec: "permit 10.244.0.0/16 le 32",
 						},
 					},
 					RouteMaps: []switcher.RouteMap{

--- a/internal/switcher/test_data/customtpl/frr.conf
+++ b/internal/switcher/test_data/customtpl/frr.conf
@@ -69,7 +69,7 @@ route-map LOCALS permit 12
  match interface vlan4000
 !
 # route-maps for firewall@swp3
-ip prefix-list fw-swp3-in-prefixes seq 10 permit 10.0.2.1/32 le 32
+ip prefix-list fw-swp3-in-prefixes permit 10.0.2.1/32 le 32
 route-map fw-swp3-in permit 10
  match ip address prefix-list fw-swp3-in-prefixes
 route-map fw-swp3-vni permit 10
@@ -99,9 +99,9 @@ router bgp 4200000010 vrf vrf104001
  exit-address-family
 !
 # route-maps for vrf104001
-ip prefix-list vrf104001-in-prefixes seq 10 permit 100.127.131.0/24 le 32
-ip prefix-list vrf104001-in-prefixes seq 11 permit 212.17.234.17/32 le 32
-ip prefix-list vrf104001-in-prefixes seq 12 permit 10.244.0.0/16 le 32
+ip prefix-list vrf104001-in-prefixes permit 100.127.131.0/24 le 32
+ip prefix-list vrf104001-in-prefixes permit 212.17.234.17/32 le 32
+ip prefix-list vrf104001-in-prefixes permit 10.244.0.0/16 le 32
 route-map vrf104001-in permit 10
  match ip address prefix-list vrf104001-in-prefixes
 !

--- a/internal/switcher/test_data/dev/frr.conf
+++ b/internal/switcher/test_data/dev/frr.conf
@@ -66,7 +66,7 @@ route-map LOOPBACKS permit 10
  match interface lo
 !
 # route-maps for firewall@swp3
-ip prefix-list fw-swp3-in-prefixes seq 10 permit 10.0.2.1/32 le 32
+ip prefix-list fw-swp3-in-prefixes permit 10.0.2.1/32 le 32
 route-map fw-swp3-in permit 10
  match ip address prefix-list fw-swp3-in-prefixes
 route-map fw-swp3-vni permit 10
@@ -98,9 +98,9 @@ router bgp 4200000010 vrf vrf104001
  exit-address-family
 !
 # route-maps for vrf104001
-ip prefix-list vrf104001-in-prefixes seq 10 permit 100.127.131.0/24 le 32
-ip prefix-list vrf104001-in-prefixes seq 11 permit 212.17.234.17/32 le 32
-ip prefix-list vrf104001-in-prefixes seq 12 permit 10.244.0.0/16 le 32
+ip prefix-list vrf104001-in-prefixes permit 100.127.131.0/24 le 32
+ip prefix-list vrf104001-in-prefixes permit 212.17.234.17/32 le 32
+ip prefix-list vrf104001-in-prefixes permit 10.244.0.0/16 le 32
 route-map vrf104001-in permit 10
  match ip address prefix-list vrf104001-in-prefixes
 !

--- a/internal/switcher/test_data/lab/frr.conf
+++ b/internal/switcher/test_data/lab/frr.conf
@@ -66,7 +66,7 @@ route-map LOOPBACKS permit 10
  match interface lo
 !
 # route-maps for firewall@swp3
-ip prefix-list fw-swp3-in-prefixes seq 10 permit 10.0.2.1/32 le 32
+ip prefix-list fw-swp3-in-prefixes permit 10.0.2.1/32 le 32
 route-map fw-swp3-in permit 10
  match ip address prefix-list fw-swp3-in-prefixes
 route-map fw-swp3-vni permit 10
@@ -98,7 +98,7 @@ router bgp 4200000010 vrf vrf104001
  exit-address-family
 !
 # route-maps for vrf104001
-ip prefix-list vrf104001-in-prefixes seq 10 permit 10.244.0.0/16 le 32
+ip prefix-list vrf104001-in-prefixes permit 10.244.0.0/16 le 32
 route-map vrf104001-in permit 10
  match ip address prefix-list vrf104001-in-prefixes
 !

--- a/internal/switcher/types.go
+++ b/internal/switcher/types.go
@@ -78,8 +78,8 @@ func (s *Filter) Assemble(rmPrefix string, vnis, cidrs []string) {
 		}
 		s.RouteMaps = append(s.RouteMaps, rm)
 
-		for j, cidr := range cidrs {
-			spec := fmt.Sprintf("seq %d permit %s le 32", 10+j, cidr)
+		for _, cidr := range cidrs {
+			spec := fmt.Sprintf("permit %s le 32", cidr)
 			prefixList := IPPrefixList{
 				Name: prefixListName,
 				Spec: spec,


### PR DESCRIPTION
Do not generate sequence numbers in prefix list to prevent route churn on every changed prefix.
