### PR TITLE
Don't power off LED when registering a machine.

### DIFF
--- a/internal/endpoint/register.go
+++ b/internal/endpoint/register.go
@@ -53,7 +53,5 @@ func (h *endpointHandler) Register(request *restful.Request, response *restful.R
 		zap.Any("machine", machine),
 	)
 
-	h.EventHandler().PowerOffChassisIdentifyLED(machineID, "Machine registered")
-
 	rest.Respond(response, http.StatusOK, machine)
 }


### PR DESCRIPTION
This is unrelated to the registration process and is a potential cause for timeouts in the mini-lab where no BMC is present.