### PR TITLE
Remove vagrant leftover

### DIFF
--- a/cmd/metalcore/create.go
+++ b/cmd/metalcore/create.go
@@ -45,10 +45,7 @@ func Create() *Server {
 
 	log.Info("metal-core version", zap.Any("version", v.V))
 
-	devMode := strings.Contains(cfg.PartitionID, "vagrant")
-
 	log.Info("configuration",
-		zap.Bool("DevMode", devMode),
 		zap.String("CIDR", cfg.CIDR),
 		zap.String("PartitionID", cfg.PartitionID),
 		zap.String("RackID", cfg.RackID),
@@ -87,7 +84,6 @@ func Create() *Server {
 			MachineClient:   machine.New(transport, strfmt.Default),
 			PartitionClient: partition.New(transport, strfmt.Default),
 			SwitchClient:    sw.New(transport, strfmt.Default),
-			DevMode:         devMode,
 			Log:             log,
 		},
 	}

--- a/internal/event/reconfigureSwitch.go
+++ b/internal/event/reconfigureSwitch.go
@@ -63,7 +63,7 @@ func (h *eventHandler) reconfigureSwitch(switchName string) error {
 		return fmt.Errorf("could not build switcher config: %w", err)
 	}
 
-	err = fillEth0Info(c, h.Config.ManagementGateway, h.DevMode)
+	err = fillEth0Info(c, h.Config.ManagementGateway)
 	if err != nil {
 		return fmt.Errorf("could not gather information about eth0 nic: %w", err)
 	}
@@ -182,7 +182,7 @@ func mapLogLevel(level string) string {
 	}
 }
 
-func fillEth0Info(c *switcher.Conf, gw string, devMode bool) error {
+func fillEth0Info(c *switcher.Conf, gw string) error {
 	c.Ports.Eth0 = switcher.Nic{}
 	eth0, err := netlink.LinkByName("eth0")
 	if err != nil {
@@ -200,7 +200,6 @@ func fillEth0Info(c *switcher.Conf, gw string, devMode bool) error {
 	s, _ := addrs[0].IPNet.Mask.Size()
 	c.Ports.Eth0.AddressCIDR = fmt.Sprintf("%s/%d", ip.String(), s)
 	c.Ports.Eth0.Gateway = gw
-	c.DevMode = devMode
 	return nil
 }
 

--- a/internal/switcher/test_data/customtpl/interfaces.tpl
+++ b/internal/switcher/test_data/customtpl/interfaces.tpl
@@ -15,11 +15,6 @@ iface eth0
     address {{ .Ports.Eth0.AddressCIDR }}
     gateway {{ .Ports.Eth0.Gateway }}
     vrf mgmt
-{{- if .DevMode  }}
-
-auto vagrant
-iface vagrant inet dhcp
-{{- end }}
 
 auto mgmt
 iface mgmt

--- a/internal/switcher/test_data/lab/conf.yaml
+++ b/internal/switcher/test_data/lab/conf.yaml
@@ -3,7 +3,6 @@ name: leaf01
 loglevel: debugging
 loopback: 10.0.0.10
 asn: 4200000010
-devmode: true
 metalcorecidr: 10.255.255.2/24
 ports:
   eth0:

--- a/internal/switcher/test_data/lab/interfaces
+++ b/internal/switcher/test_data/lab/interfaces
@@ -15,9 +15,6 @@ iface eth0
     gateway 192.168.0.254
     vrf mgmt
 
-auto vagrant
-iface vagrant inet dhcp
-
 auto mgmt
 iface mgmt
     address 127.0.0.1/8

--- a/internal/switcher/test_data/notenants/conf.yaml
+++ b/internal/switcher/test_data/notenants/conf.yaml
@@ -3,7 +3,6 @@ name: leaf01
 loglevel: warnings
 loopback: 10.0.0.10
 asn: 4200000010
-devmode: true
 metalcorecidr: 10.255.255.2/24
 ports:
   eth0:

--- a/internal/switcher/test_data/notenants/interfaces
+++ b/internal/switcher/test_data/notenants/interfaces
@@ -15,9 +15,6 @@ iface eth0
     gateway 192.168.0.254
     vrf mgmt
 
-auto vagrant
-iface vagrant inet dhcp
-
 auto mgmt
 iface mgmt
     address 127.0.0.1/8

--- a/internal/switcher/tpl/interfaces.tpl
+++ b/internal/switcher/tpl/interfaces.tpl
@@ -15,11 +15,6 @@ iface eth0
     address {{ .Ports.Eth0.AddressCIDR }}
     gateway {{ .Ports.Eth0.Gateway }}
     vrf mgmt
-{{- if .DevMode  }}
-
-auto vagrant
-iface vagrant inet dhcp
-{{- end }}
 
 auto mgmt
 iface mgmt

--- a/internal/switcher/types.go
+++ b/internal/switcher/types.go
@@ -9,7 +9,6 @@ type Conf struct {
 	Loopback             string
 	ASN                  uint32
 	Ports                Ports
-	DevMode              bool
 	MetalCoreCIDR        string
 	AdditionalBridgeVIDs []string
 	FrrTplFile           string

--- a/pkg/domain/model.go
+++ b/pkg/domain/model.go
@@ -196,7 +196,6 @@ type AppContext struct {
 	PartitionClient partition.ClientService
 	hmac            security.HMACAuth
 	Auth            runtime.ClientAuthInfoWriter
-	DevMode         bool
 	Log             *zap.Logger
 }
 


### PR DESCRIPTION
The DevMode is still present, although it is not needed anymore after the migration of the minilab from Vagrant to containerlab.