### PR TITLE
Make compile work locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,20 @@
-FROM metalstack/builder:latest as builder
+FROM golang:1.19-alpine3.16 as builder
+WORKDIR /work
+COPY . .
+RUN apk add \
+    make \
+    binutils \
+    git \
+    gcc \
+    libpcap-dev \
+    musl-dev \
+    dbus-libs
+RUN make
 
 FROM alpine:3.16
 
 RUN apk add \
+    libpcap \
     ca-certificates
 COPY --from=builder /work/bin/metal-core /
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ in-docker: gofmt test all;
 
 release:: gofmt test all;
 
-LINKMODE := -linkmode external -extldflags '-static -s -w' \
+LINKMODE := -linkmode external -extldflags '-s -w' \
 		 -X 'github.com/metal-stack/v.Version=$(VERSION)' \
 		 -X 'github.com/metal-stack/v.Revision=$(GITVERSION)' \
 		 -X 'github.com/metal-stack/v.GitSHA1=$(SHA)' \

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Besides that, it ensures the proper boot order (IPMI) and monitors their livelin
 
 ## Build
 
-```
+Ensure you have `libpcap-dev` installed.
+
+```bash
 make
 ```


### PR DESCRIPTION
With this a long standing issue is fixed, building locally on my workstation fails always with:

```
...
(.text+0x103): undefined reference to `dbus_message_demarshal'
/usr/bin/ld: (.text+0x119): undefined reference to `dbus_connection_send'
/usr/bin/ld: (.text+0x122): undefined reference to `dbus_connection_flush'
/usr/bin/ld: (.text+0x12a): undefined reference to `dbus_message_unref'
/usr/bin/ld: (.text+0x178): undefined reference to `dbus_error_free'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/11/../../../x86_64-linux-gnu/libpcap.a(pcap-dbus.o): in function `dbus_read':
...
```
This also prevents us from using `bullseye` as builder because there the same error occurs.

The whole problem is caused by the `-static` linkmode.