### PR TITLE
Remove VLAN membership and VRF bindings from configdb patch

### DIFF
--- a/cmd/internal/switcher/templates/configdb.go
+++ b/cmd/internal/switcher/templates/configdb.go
@@ -19,8 +19,6 @@ const (
 	metalCoreConfigdb     = "/etc/sonic/metal.json"
 	metalCoreConfigdbTmp  = "/etc/sonic/metal.tmp"
 	configdbReloadService = "write-to-db"
-
-	untagged = "untagged"
 )
 
 type configdb struct {

--- a/cmd/internal/switcher/templates/test_data/dev/configdb.json
+++ b/cmd/internal/switcher/templates/test_data/dev/configdb.json
@@ -9,18 +9,7 @@
     "Loopback0|10.0.0.10/32": {}
   },
   "INTERFACE": {
-    "swp1": {
-      "vrf_name": "vrf104001"
-    },
-    "swp1|10.0.0.10": null,
-    "swp2": {
-      "vrf_name": "vrf104001"
-    },
-    "swp3": {},
-    "swp31": {},
-    "swp32": {},
-    "swp4": {},
-    "swp5": {}
+    "swp1|10.0.0.10": null
   },
   "PORT": {
     "swp1": {
@@ -66,14 +55,6 @@
     "Vlan4000|10.255.255.2/24": {},
     "Vlan4001": {
       "vrf_name": "vrf104001"
-    }
-  },
-  "VLAN_MEMBER": {
-    "Vlan4000|swp4": {
-      "tagging_mode": "untagged"
-    },
-    "Vlan4000|swp5": {
-      "tagging_mode": "untagged"
     }
   },
   "VRF": {

--- a/cmd/internal/switcher/templates/test_data/lab/configdb.json
+++ b/cmd/internal/switcher/templates/test_data/lab/configdb.json
@@ -9,18 +9,7 @@
     "Loopback0|10.0.0.10/32": {}
   },
   "INTERFACE": {
-    "swp1": {
-      "vrf_name": "vrf104001"
-    },
-    "swp1|10.0.0.10": null,
-    "swp2": {
-      "vrf_name": "vrf104001"
-    },
-    "swp3": {},
-    "swp31": {},
-    "swp32": {},
-    "swp4": {},
-    "swp5": {}
+    "swp1|10.0.0.10": null
   },
   "PORT": {
     "swp1": {
@@ -66,14 +55,6 @@
     "Vlan4000|10.255.255.2/24": {},
     "Vlan4001": {
       "vrf_name": "vrf104001"
-    }
-  },
-  "VLAN_MEMBER": {
-    "Vlan4000|swp4": {
-      "tagging_mode": "untagged"
-    },
-    "Vlan4000|swp5": {
-      "tagging_mode": "untagged"
     }
   },
   "VRF": {

--- a/cmd/internal/switcher/templates/test_data/notenants/configdb.json
+++ b/cmd/internal/switcher/templates/test_data/notenants/configdb.json
@@ -9,11 +9,7 @@
     "Loopback0|10.0.0.10/32": {}
   },
   "INTERFACE": {
-    "swp1": {},
-    "swp1|10.0.0.10": null,
-    "swp2": {},
-    "swp31": {},
-    "swp32": {}
+    "swp1|10.0.0.10": null
   },
   "PORT": {
     "swp1": {
@@ -42,14 +38,6 @@
   "VLAN_INTERFACE": {
     "Vlan4000": {},
     "Vlan4000|10.255.255.2/24": {}
-  },
-  "VLAN_MEMBER": {
-    "Vlan4000|swp1": {
-      "tagging_mode": "untagged"
-    },
-    "Vlan4000|swp2": {
-      "tagging_mode": "untagged"
-    }
   },
   "VRF": {},
   "VXLAN_EVPN_NVO": {


### PR DESCRIPTION
Have to leave the `INTERFACE` table as it's required for removing IPs for front-panel interfaces,