### PR TITLE
Spineuplinks as string slice

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	ApiBasePath               string        `required:"false" default:"" desc:"set metal api basepath" envconfig:"metal_api_basepath"`
 	LoopbackIP                string        `required:"false" default:"10.0.0.11" desc:"set the loopback ip address that is used with BGP unnumbered" split_words:"true"`
 	ASN                       string        `required:"false" default:"420000011" desc:"set the ASN that is used with BGP"`
-	SpineUplinks              string        `required:"false" default:"swp31,swp32" desc:"set the ports that are connected to spines" split_words:"true"`
+	SpineUplinks              []string      `required:"false" default:"swp31,swp32" desc:"set the ports that are connected to spines" envconfig:"spine_uplinks"`
 	ManagementGateway         string        `required:"false" default:"192.168.0.1" desc:"the default gateway for the management network" split_words:"true"`
 	ReconfigureSwitch         bool          `required:"false" default:"false" desc:"let metal-core reconfigure the switch" split_words:"true"`
 	ReconfigureSwitchInterval time.Duration `required:"false" default:"10s" desc:"pull interval to fetch and apply switch configuration" split_words:"true"`

--- a/cmd/internal/core/core.go
+++ b/cmd/internal/core/core.go
@@ -29,7 +29,7 @@ type Core struct {
 	managementGateway         string
 	additionalBridgePorts     []string
 	additionalBridgeVIDs      []string
-	spineUplinks              string
+	spineUplinks              []string
 
 	nos NOS
 
@@ -51,7 +51,7 @@ type Config struct {
 	ManagementGateway         string
 	AdditionalBridgePorts     []string
 	AdditionalBridgeVIDs      []string
-	SpineUplinks              string
+	SpineUplinks              []string
 
 	NOS NOS
 

--- a/cmd/internal/core/reconfigure-switch.go
+++ b/cmd/internal/core/reconfigure-switch.go
@@ -96,7 +96,7 @@ func (c *Core) buildSwitcherConfig(s *models.V1SwitchResponse) (*switcher.Conf, 
 	}
 
 	p := switcher.Ports{
-		Underlay:      strings.Split(c.spineUplinks, ","),
+		Underlay:      c.spineUplinks,
 		Unprovisioned: []string{},
 		Vrfs:          map[string]*switcher.Vrf{},
 		Firewalls:     map[string]*switcher.Firewall{},

--- a/cmd/internal/core/reconfigure-switch_test.go
+++ b/cmd/internal/core/reconfigure-switch_test.go
@@ -15,7 +15,7 @@ func TestBuildSwitcherConfig(t *testing.T) {
 		rackID:               "rack01",
 		asn:                  "420000001",
 		loopbackIP:           "10.0.0.1",
-		spineUplinks:         "swp31,swp32",
+		spineUplinks:         []string{"swp31", "swp32"},
 		additionalBridgeVIDs: []string{"201-256", "301-356"},
 	}
 


### PR DESCRIPTION
Spineuplinks where splitted from a string, this can be done native with envconfig.

Also removes some unrelated changes from #81 