### PR TITLE
Remove fec config from sonic applier

### DIFF
--- a/cmd/internal/switcher/sonic/db/asicdb.go
+++ b/cmd/internal/switcher/sonic/db/asicdb.go
@@ -55,13 +55,3 @@ func (d *AsicDB) ExistRouterInterface(ctx context.Context, rif OID) (bool, error
 
 	return d.c.Exists(ctx, key)
 }
-
-func (d *AsicDB) InFecModeRs(ctx context.Context, port OID) (bool, error) {
-	key := Key{"ASIC_STATE", "SAI_OBJECT_TYPE_PORT", string(port)}
-
-	result, err := d.c.HGet(ctx, key, "SAI_PORT_ATTR_FEC_MODE")
-	if err != nil {
-		return false, err
-	}
-	return result == "SAI_PORT_FEC_MODE_RS", err
-}

--- a/cmd/internal/switcher/sonic/db/configdb.go
+++ b/cmd/internal/switcher/sonic/db/configdb.go
@@ -18,9 +18,6 @@ const (
 	adminStatusUp   = "up"
 	adminStatusDown = "down"
 	mtu             = "mtu"
-	fec             = "fec"
-	fecRS           = "rs"
-	fecNone         = "none"
 )
 
 type ConfigDB struct {
@@ -30,7 +27,6 @@ type ConfigDB struct {
 type Port struct {
 	AdminStatus bool
 	Mtu         string
-	FecRs       bool
 }
 
 func newConfigDB(addr string, id int, sep string) *ConfigDB {
@@ -182,21 +178,7 @@ func (d *ConfigDB) GetPort(ctx context.Context, interfaceName string) (*Port, er
 	return &Port{
 		AdminStatus: result[adminStatus] == adminStatusUp,
 		Mtu:         result[mtu],
-		FecRs:       result[fec] == fecRS,
 	}, nil
-}
-
-func (d *ConfigDB) SetPortFecMode(ctx context.Context, interfaceName string, isFecRs bool) error {
-	key := Key{portTable, interfaceName}
-
-	var mode string
-	if isFecRs {
-		mode = fecRS
-	} else {
-		mode = fecNone
-	}
-
-	return d.c.HSet(ctx, key, Val{fec: mode})
 }
 
 func (d *ConfigDB) SetPortMtu(ctx context.Context, interfaceName string, val string) error {

--- a/cmd/internal/switcher/sonic/redis/applier.go
+++ b/cmd/internal/switcher/sonic/redis/applier.go
@@ -126,7 +126,7 @@ func (a *Applier) configureUnprovisionedPort(interfaceName string, isUp bool, px
 	}
 
 	// unprovisioned ports should be up
-	if err := a.ensurePortConfiguration(ctx, interfaceName, "9000", true, isUp); err != nil {
+	if err := a.ensurePortConfiguration(ctx, interfaceName, "9000", isUp); err != nil {
 		return fmt.Errorf("failed to update Port info for interface %s: %w", interfaceName, err)
 	}
 
@@ -143,7 +143,7 @@ func (a *Applier) configureFirewallPort(interfaceName string, isUp bool) error {
 	}
 
 	// a firewall port should always be up
-	if err := a.ensurePortConfiguration(ctx, interfaceName, "9216", true, isUp); err != nil {
+	if err := a.ensurePortConfiguration(ctx, interfaceName, "9216", isUp); err != nil {
 		return fmt.Errorf("failed to update Port info for interface %s: %w", interfaceName, err)
 	}
 
@@ -155,7 +155,7 @@ func (a *Applier) configureUnderlayPort(interfaceName string, isUp bool) error {
 	defer cancel()
 
 	// underlay ports should be up
-	if err := a.ensurePortConfiguration(ctx, interfaceName, "9216", false, isUp); err != nil {
+	if err := a.ensurePortConfiguration(ctx, interfaceName, "9216", isUp); err != nil {
 		return fmt.Errorf("failed to update Port info for interface %s: %w", interfaceName, err)
 	}
 	return a.ensureLinkLocalOnlyIsEnabled(ctx, interfaceName)
@@ -175,7 +175,7 @@ func (a *Applier) configureVrfNeighbor(interfaceName, vrfName string, isUp bool)
 		return err
 	}
 
-	if err := a.ensurePortConfiguration(ctx, interfaceName, "9000", true, isUp); err != nil {
+	if err := a.ensurePortConfiguration(ctx, interfaceName, "9000", isUp); err != nil {
 		return fmt.Errorf("failed to update Port info for interface %s: %w", interfaceName, err)
 	}
 

--- a/cmd/internal/switcher/sonic/redis/port.go
+++ b/cmd/internal/switcher/sonic/redis/port.go
@@ -3,22 +3,12 @@ package redis
 import (
 	"context"
 	"fmt"
-
-	"github.com/avast/retry-go/v4"
 )
 
-func (a *Applier) ensurePortConfiguration(ctx context.Context, portName, mtu string, isFecRs, isUp bool) error {
+func (a *Applier) ensurePortConfiguration(ctx context.Context, portName, mtu string, isUp bool) error {
 	p, err := a.db.Config.GetPort(ctx, portName)
 	if err != nil {
 		return fmt.Errorf("could not retrieve port info for %s from redis: %w", portName, err)
-	}
-
-	if p.FecRs != isFecRs {
-		a.log.Debug("set port rs mode to", "port", portName, "mode", isFecRs)
-		err = a.ensurePortFecMode(ctx, portName, isFecRs)
-		if err != nil {
-			return err
-		}
 	}
 
 	if p.Mtu != mtu {
@@ -35,29 +25,4 @@ func (a *Applier) ensurePortConfiguration(ctx context.Context, portName, mtu str
 	}
 
 	return nil
-}
-
-func (a *Applier) ensurePortFecMode(ctx context.Context, portName string, wantFecRs bool) error {
-	err := a.db.Config.SetPortFecMode(ctx, portName, wantFecRs)
-	if err != nil {
-		return fmt.Errorf("could not update Fec for port %s: %w", portName, err)
-	}
-
-	oid, ok := a.portOidMap[portName]
-	if !ok {
-		return fmt.Errorf("no mapping of port %s to OID", portName)
-	}
-
-	return retry.Do(
-		func() error {
-			isFecRs, err := a.db.Asic.InFecModeRs(ctx, oid)
-			if err != nil {
-				return err
-			}
-			if isFecRs != wantFecRs {
-				return fmt.Errorf("port %s still has rs mode = %v, but want %v", portName, isFecRs, wantFecRs)
-			}
-			return nil
-		},
-	)
 }


### PR DESCRIPTION
## Breaking Change

```BREAKING_CHANGE
metal-core does not write FEC configuration on ports anymore. If FEC is needed, it must be configured another way, e.g. by Ansible.
```