### PR TITLE
Support authentication against Redis

### DIFF
--- a/cmd/internal/switcher/sonic/db/appldb.go
+++ b/cmd/internal/switcher/sonic/db/appldb.go
@@ -2,15 +2,17 @@ package db
 
 import (
 	"context"
+
+	"github.com/redis/go-redis/v9"
 )
 
 type ApplDB struct {
 	c *Client
 }
 
-func newApplDB(addr string, id int, sep string) *ApplDB {
+func newApplDB(rdb *redis.Client, sep string) *ApplDB {
 	return &ApplDB{
-		c: NewClient(addr, id, sep),
+		c: NewClient(rdb, sep),
 	}
 }
 

--- a/cmd/internal/switcher/sonic/db/asicdb.go
+++ b/cmd/internal/switcher/sonic/db/asicdb.go
@@ -13,9 +13,9 @@ type AsicDB struct {
 
 type OID string
 
-func newAsicDB(addr string, id int, sep string) *AsicDB {
+func newAsicDB(rdb *redis.Client, sep string) *AsicDB {
 	return &AsicDB{
-		c: NewClient(addr, id, sep),
+		c: NewClient(rdb, sep),
 	}
 }
 

--- a/cmd/internal/switcher/sonic/db/client.go
+++ b/cmd/internal/switcher/sonic/db/client.go
@@ -21,12 +21,7 @@ type Client struct {
 	sep string
 }
 
-func NewClient(addr string, id int, sep string) *Client {
-	rdb := redis.NewClient(&redis.Options{
-		Addr:     addr,
-		DB:       id,
-		PoolSize: 1,
-	})
+func NewClient(rdb *redis.Client, sep string) *Client {
 	return &Client{
 		rdb: rdb,
 		sep: sep,

--- a/cmd/internal/switcher/sonic/db/configdb.go
+++ b/cmd/internal/switcher/sonic/db/configdb.go
@@ -3,6 +3,8 @@ package db
 import (
 	"context"
 	"fmt"
+
+	"github.com/redis/go-redis/v9"
 )
 
 const (
@@ -29,9 +31,9 @@ type Port struct {
 	Mtu         string
 }
 
-func newConfigDB(addr string, id int, sep string) *ConfigDB {
+func newConfigDB(rdb *redis.Client, sep string) *ConfigDB {
 	return &ConfigDB{
-		c: NewClient(addr, id, sep),
+		c: NewClient(rdb, sep),
 	}
 }
 

--- a/cmd/internal/switcher/sonic/db/countersdb.go
+++ b/cmd/internal/switcher/sonic/db/countersdb.go
@@ -2,15 +2,17 @@ package db
 
 import (
 	"context"
+
+	"github.com/redis/go-redis/v9"
 )
 
 type CountersDB struct {
 	c *Client
 }
 
-func newCountersDB(addr string, id int, sep string) *CountersDB {
+func newCountersDB(rdb *redis.Client, sep string) *CountersDB {
 	return &CountersDB{
-		c: NewClient(addr, id, sep),
+		c: NewClient(rdb, sep),
 	}
 }
 

--- a/cmd/internal/switcher/sonic/db/db.go
+++ b/cmd/internal/switcher/sonic/db/db.go
@@ -1,5 +1,12 @@
 package db
 
+import (
+	"fmt"
+	"os"
+
+	"github.com/redis/go-redis/v9"
+)
+
 type Config struct {
 	Databases map[string]database `json:"DATABASES"`
 	Instances map[string]instance `json:"INSTANCES"`
@@ -12,7 +19,8 @@ type database struct {
 }
 
 type instance struct {
-	Addr string `json:"unix_socket_path"`
+	Addr         string `json:"unix_socket_path"`
+	PasswordPath string `json:"password_path"`
 }
 
 type DB struct {
@@ -22,16 +30,63 @@ type DB struct {
 	Counters *CountersDB
 }
 
-func New(cfg *Config) *DB {
+func New(cfg *Config) (*DB, error) {
 	applDB := cfg.Databases["APPL_DB"]
 	asicDB := cfg.Databases["ASIC_DB"]
 	configDB := cfg.Databases["CONFIG_DB"]
 	countersDB := cfg.Databases["COUNTERS_DB"]
 
-	return &DB{
-		Appl:     newApplDB(cfg.Instances[applDB.Instance].Addr, applDB.Id, applDB.Separator),
-		Asic:     newAsicDB(cfg.Instances[asicDB.Instance].Addr, asicDB.Id, asicDB.Separator),
-		Config:   newConfigDB(cfg.Instances[configDB.Instance].Addr, configDB.Id, configDB.Separator),
-		Counters: newCountersDB(cfg.Instances[countersDB.Instance].Addr, countersDB.Id, countersDB.Separator),
+	applClient, err := newRedisClient(cfg.Instances[applDB.Instance], applDB.Id)
+	if err != nil {
+		return nil, fmt.Errorf("could not create client for APPL_DB: %w", err)
 	}
+
+	asicClient, err := newRedisClient(cfg.Instances[asicDB.Instance], asicDB.Id)
+	if err != nil {
+		return nil, fmt.Errorf("could not create client for ASIC_DB: %w", err)
+	}
+
+	configClient, err := newRedisClient(cfg.Instances[configDB.Instance], configDB.Id)
+	if err != nil {
+		return nil, fmt.Errorf("could not create client for CONFIG_DB: %w", err)
+	}
+
+	countersClient, err := newRedisClient(cfg.Instances[countersDB.Instance], countersDB.Id)
+	if err != nil {
+		return nil, fmt.Errorf("could not create client for COUNTERS_DB: %w", err)
+	}
+
+	db := &DB{
+		Appl:     newApplDB(applClient, applDB.Separator),
+		Asic:     newAsicDB(asicClient, asicDB.Separator),
+		Config:   newConfigDB(configClient, configDB.Separator),
+		Counters: newCountersDB(countersClient, countersDB.Separator),
+	}
+	return db, nil
+}
+
+func newRedisClient(redisInstance instance, redisDatabase int) (*redis.Client, error) {
+	if redisInstance.PasswordPath != "" {
+		return newRedisClientWithAuth(redisInstance, redisDatabase)
+	}
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     redisInstance.Addr,
+		DB:       redisDatabase,
+		PoolSize: 1,
+	})
+	return rdb, nil
+}
+
+func newRedisClientWithAuth(redisInstance instance, redisDatabase int) (*redis.Client, error) {
+	passwd, err := os.ReadFile(redisInstance.PasswordPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read password from %s: %w", redisInstance.PasswordPath, err)
+	}
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     redisInstance.Addr,
+		DB:       redisDatabase,
+		PoolSize: 1,
+		Password: string(passwd),
+	})
+	return rdb, nil
 }

--- a/cmd/internal/switcher/sonic/sonic.go
+++ b/cmd/internal/switcher/sonic/sonic.go
@@ -44,7 +44,10 @@ func New(log *slog.Logger, frrTplFile string) (*Sonic, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to load database config for SONiC: %w", err)
 	}
-	sonicDb := db.New(cfg)
+	sonicDb, err := db.New(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to SONiC databases: %w", err)
+	}
 
 	return &Sonic{
 		db:           sonicDb,


### PR DESCRIPTION
## Description

Clients have to authenticated against Redis in Broadcom SONiC.

```
{
    "INSTANCES": {
        "redis2": {
            "unix_socket_path": "/var/run/redis/redis2.sock",
            "password_path": "/run/redis/auth/passwd"
        }
    },
    "DATABASES": {
        "APPL_DB": {
            "id": 0,
            "separator": ":",
            "instance": "redis2"
        }
    }
}
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
