### PR TITLE
Workaround for Edgecore Enterprise SONiC 202211

### DIFF
--- a/cmd/internal/switcher/templates/test_data/dev/cumulus_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/dev/cumulus_frr.conf
@@ -66,7 +66,6 @@ router bgp 4200000010
   neighbor FABRIC allowas-in 2
   neighbor FIREWALL activate
   neighbor FIREWALL allowas-in 2
-  neighbor swp3 route-map fw-swp3-vni out
  exit-address-family
 !
 route-map LOOPBACKS permit 10
@@ -76,12 +75,6 @@ route-map LOOPBACKS permit 10
 ip prefix-list fw-swp3-in-prefixes permit 10.0.2.1/32 le 32
 route-map fw-swp3-in permit 10
  match ip address prefix-list fw-swp3-in-prefixes
-route-map fw-swp3-vni permit 10
- match evpn vni 104001
-route-map fw-swp3-vni permit 11
- match evpn vni 104009
-route-map fw-swp3-vni permit 12
- match evpn vni 104010
 !
 ip route 0.0.0.0/0 192.168.101.1 nexthop-vrf mgmt
 !

--- a/cmd/internal/switcher/templates/test_data/dev/customtpl/frr.conf
+++ b/cmd/internal/switcher/templates/test_data/dev/customtpl/frr.conf
@@ -59,7 +59,6 @@ router bgp 4200000010
   neighbor FABRIC allowas-in 2
   neighbor FIREWALL activate
   neighbor FIREWALL allowas-in 2
-  neighbor swp3 route-map fw-swp3-vni out
  exit-address-family
 !
 route-map LOCALS permit 10
@@ -72,12 +71,6 @@ route-map LOCALS permit 12
 ip prefix-list fw-swp3-in-prefixes permit 10.0.2.1/32 le 32
 route-map fw-swp3-in permit 10
  match ip address prefix-list fw-swp3-in-prefixes
-route-map fw-swp3-vni permit 10
- match evpn vni 104001
-route-map fw-swp3-vni permit 11
- match evpn vni 104009
-route-map fw-swp3-vni permit 12
- match evpn vni 104010
 !
 router bgp 4200000010 vrf vrf104001
  bgp router-id 10.0.0.10

--- a/cmd/internal/switcher/templates/test_data/dev/customtpl/frr.tpl
+++ b/cmd/internal/switcher/templates/test_data/dev/customtpl/frr.tpl
@@ -66,9 +66,6 @@ router bgp {{ $ASN }}
   neighbor FABRIC allowas-in 2
   neighbor FIREWALL activate
   neighbor FIREWALL allowas-in 2
-  {{- range $k, $f := .Ports.Firewalls }}
-  neighbor {{ $f.Port }} route-map fw-{{ $k }}-vni out
-  {{- end }}
  exit-address-family
 !
 route-map LOCALS permit 10

--- a/cmd/internal/switcher/templates/test_data/dev/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/dev/sonic_frr.conf
@@ -74,7 +74,6 @@ router bgp 4200000010
   neighbor FABRIC allowas-in 2
   neighbor FIREWALL activate
   neighbor FIREWALL allowas-in 2
-  neighbor swp3 route-map fw-swp3-vni out
  exit-address-family
 !
 route-map DENY_MGMT deny 10
@@ -85,12 +84,6 @@ route-map DENY_MGMT permit 20
 ip prefix-list fw-swp3-in-prefixes permit 10.0.2.1/32 le 32
 route-map fw-swp3-in permit 10
  match ip address prefix-list fw-swp3-in-prefixes
-route-map fw-swp3-vni permit 10
- match evpn vni 104001
-route-map fw-swp3-vni permit 11
- match evpn vni 104009
-route-map fw-swp3-vni permit 12
- match evpn vni 104010
 !
 ip route 0.0.0.0/0 192.168.101.1 nexthop-vrf mgmt
 !

--- a/cmd/internal/switcher/templates/test_data/dev/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/dev/sonic_frr.conf
@@ -134,5 +134,11 @@ route-map Vrf104001-in permit 10
 route-map Vrf104001-in6 permit 10
  match ipv6 address prefix-list Vrf104001-in6-prefixes
 !
+route-map RM_SET_SRC permit 10
+ set src 10.0.0.10
+exit
+!
+ip protocol bgp route-map RM_SET_SRC
+!
 line vty
 !

--- a/cmd/internal/switcher/templates/test_data/lab/cumulus_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/lab/cumulus_frr.conf
@@ -66,7 +66,6 @@ router bgp 4200000010
   neighbor FABRIC allowas-in 2
   neighbor FIREWALL activate
   neighbor FIREWALL allowas-in 2
-  neighbor swp3 route-map fw-swp3-vni out
  exit-address-family
 !
 route-map LOOPBACKS permit 10
@@ -76,12 +75,6 @@ route-map LOOPBACKS permit 10
 ip prefix-list fw-swp3-in-prefixes permit 10.0.2.1/32 le 32
 route-map fw-swp3-in permit 10
  match ip address prefix-list fw-swp3-in-prefixes
-route-map fw-swp3-vni permit 10
- match evpn vni 104001
-route-map fw-swp3-vni permit 11
- match evpn vni 104009
-route-map fw-swp3-vni permit 12
- match evpn vni 104010
 !
 ip route 0.0.0.0/0 192.168.0.254 nexthop-vrf mgmt
 !

--- a/cmd/internal/switcher/templates/test_data/lab/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/lab/sonic_frr.conf
@@ -74,7 +74,6 @@ router bgp 4200000010
   neighbor FABRIC allowas-in 2
   neighbor FIREWALL activate
   neighbor FIREWALL allowas-in 2
-  neighbor swp3 route-map fw-swp3-vni out
  exit-address-family
 !
 route-map DENY_MGMT deny 10
@@ -85,12 +84,6 @@ route-map DENY_MGMT permit 20
 ip prefix-list fw-swp3-in-prefixes permit 10.0.2.1/32 le 32
 route-map fw-swp3-in permit 10
  match ip address prefix-list fw-swp3-in-prefixes
-route-map fw-swp3-vni permit 10
- match evpn vni 104001
-route-map fw-swp3-vni permit 11
- match evpn vni 104009
-route-map fw-swp3-vni permit 12
- match evpn vni 104010
 !
 ip route 0.0.0.0/0 192.168.0.254 nexthop-vrf mgmt
 !

--- a/cmd/internal/switcher/templates/test_data/lab/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/lab/sonic_frr.conf
@@ -118,5 +118,11 @@ ip prefix-list Vrf104001-in-prefixes permit 10.240.0.0/12 le 32
 route-map Vrf104001-in permit 10
  match ip address prefix-list Vrf104001-in-prefixes
 !
+route-map RM_SET_SRC permit 10
+ set src 10.0.0.10
+exit
+!
+ip protocol bgp route-map RM_SET_SRC
+!
 line vty
 !

--- a/cmd/internal/switcher/templates/test_data/notenants/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/notenants/sonic_frr.conf
@@ -63,5 +63,11 @@ route-map DENY_MGMT permit 20
 !
 ip route 0.0.0.0/0 192.168.0.254 nexthop-vrf mgmt
 !
+route-map RM_SET_SRC permit 10
+ set src 10.0.0.10
+exit
+!
+ip protocol bgp route-map RM_SET_SRC
+!
 line vty
 !

--- a/cmd/internal/switcher/templates/tpl/cumulus_frr.tpl
+++ b/cmd/internal/switcher/templates/tpl/cumulus_frr.tpl
@@ -75,9 +75,6 @@ router bgp {{ $ASN }}
   neighbor FABRIC allowas-in 2
   neighbor FIREWALL activate
   neighbor FIREWALL allowas-in 2
-  {{- range $k, $f := .Ports.Firewalls }}
-  neighbor {{ $f.Port }} route-map fw-{{ $k }}-vni out
-  {{- end }}
  exit-address-family
 !
 route-map LOOPBACKS permit 10

--- a/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
+++ b/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
@@ -152,12 +152,6 @@ router bgp {{ $ASN }} vrf {{ $vrf }}
  {{- end }}
  exit-address-family
 !
-route-map RM_SET_SRC permit 10
- set src {{ .Loopback }}
-exit
-!
-ip protocol bgp route-map RM_SET_SRC
-!
 {{- if gt (len $t.IPPrefixLists) 0 }}
 # route-maps for {{ $vrf }}
         {{- range $t.IPPrefixLists }}
@@ -170,5 +164,11 @@ route-map {{ .Name }} {{ .Policy }} {{ .Order }}
                 {{- end }}
         {{- end }}
 !{{- end }}{{- end }}
+route-map RM_SET_SRC permit 10
+ set src {{ .Loopback }}
+exit
+!
+ip protocol bgp route-map RM_SET_SRC
+!
 line vty
 !

--- a/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
+++ b/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
@@ -83,9 +83,6 @@ router bgp {{ $ASN }}
   neighbor FABRIC allowas-in 2
   neighbor FIREWALL activate
   neighbor FIREWALL allowas-in 2
-  {{- range $k, $f := .Ports.Firewalls }}
-  neighbor {{ $f.Port }} route-map fw-{{ $k }}-vni out
-  {{- end }}
  exit-address-family
 !
 route-map DENY_MGMT deny 10

--- a/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
+++ b/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
@@ -152,6 +152,12 @@ router bgp {{ $ASN }} vrf {{ $vrf }}
  {{- end }}
  exit-address-family
 !
+route-map RM_SET_SRC permit 10
+ set src {{ .Loopback }}
+exit
+!
+ip protocol bgp route-map RM_SET_SRC
+!
 {{- if gt (len $t.IPPrefixLists) 0 }}
 # route-maps for {{ $vrf }}
         {{- range $t.IPPrefixLists }}

--- a/cmd/internal/switcher/types/types.go
+++ b/cmd/internal/switcher/types/types.go
@@ -97,18 +97,6 @@ func (s *Filter) Assemble(rmPrefix string, vnis, cidrs []string) {
 		s.RouteMaps = append(s.RouteMaps, rm)
 		s.addPrefixList(prefixListName, cidrsByAf.ipv6Cidrs, "ipv6")
 	}
-	if len(vnis) > 0 {
-		vniRouteMapName := fmt.Sprintf("%s-vni", rmPrefix)
-		for j, vni := range vnis {
-			rm := RouteMap{
-				Name:    vniRouteMapName,
-				Entries: []string{fmt.Sprintf("match evpn vni %s", vni)},
-				Policy:  "permit",
-				Order:   10 + j,
-			}
-			s.RouteMaps = append(s.RouteMaps, rm)
-		}
-	}
 }
 
 func (s *Filter) addPrefixList(prefixListName string, cidrs []string, af string) {


### PR DESCRIPTION
## Description

Workaround for https://github.com/FRRouting/frr/issues/14419#issuecomment-1836456246

Fixed in FRR 9.0.4 but Edgecore 202211 still uses FRR 9.0.1.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
