### PR TITLE
add a deny rule for vni filtering at the end of the rm

### DIFF
--- a/cmd/internal/switcher/templates/test_data/dev/cumulus_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/dev/cumulus_frr.conf
@@ -82,6 +82,7 @@ route-map fw-swp3-vni permit 11
  match evpn vni 104009
 route-map fw-swp3-vni permit 12
  match evpn vni 104010
+route-map fw-swp3-vni deny 13
 !
 ip route 0.0.0.0/0 192.168.101.1 nexthop-vrf mgmt
 !

--- a/cmd/internal/switcher/templates/test_data/dev/customtpl/frr.conf
+++ b/cmd/internal/switcher/templates/test_data/dev/customtpl/frr.conf
@@ -78,6 +78,7 @@ route-map fw-swp3-vni permit 11
  match evpn vni 104009
 route-map fw-swp3-vni permit 12
  match evpn vni 104010
+route-map fw-swp3-vni deny 13
 !
 router bgp 4200000010 vrf vrf104001
  bgp router-id 10.0.0.10

--- a/cmd/internal/switcher/templates/test_data/dev/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/dev/sonic_frr.conf
@@ -91,6 +91,7 @@ route-map fw-swp3-vni permit 11
  match evpn vni 104009
 route-map fw-swp3-vni permit 12
  match evpn vni 104010
+route-map fw-swp3-vni deny 13
 !
 ip route 0.0.0.0/0 192.168.101.1 nexthop-vrf mgmt
 !

--- a/cmd/internal/switcher/templates/test_data/lab/cumulus_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/lab/cumulus_frr.conf
@@ -82,6 +82,7 @@ route-map fw-swp3-vni permit 11
  match evpn vni 104009
 route-map fw-swp3-vni permit 12
  match evpn vni 104010
+route-map fw-swp3-vni deny 13
 !
 ip route 0.0.0.0/0 192.168.0.254 nexthop-vrf mgmt
 !

--- a/cmd/internal/switcher/templates/test_data/lab/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/lab/sonic_frr.conf
@@ -91,6 +91,7 @@ route-map fw-swp3-vni permit 11
  match evpn vni 104009
 route-map fw-swp3-vni permit 12
  match evpn vni 104010
+route-map fw-swp3-vni deny 13
 !
 ip route 0.0.0.0/0 192.168.0.254 nexthop-vrf mgmt
 !

--- a/cmd/internal/switcher/types/types.go
+++ b/cmd/internal/switcher/types/types.go
@@ -108,6 +108,13 @@ func (s *Filter) Assemble(rmPrefix string, vnis, cidrs []string) {
 			}
 			s.RouteMaps = append(s.RouteMaps, rm)
 		}
+		deny := RouteMap{
+			Name:    vniRouteMapName,
+			Entries: []string{},
+			Policy:  "deny",
+			Order:   10 + len(vnis),
+		}
+		s.RouteMaps = append(s.RouteMaps, deny)
 	}
 }
 


### PR DESCRIPTION
## Description

Newer versions of FRR expect a deny rule at the end of a VNI filtering route-map.
With this we can run community SONiC vs > 202311 in mini-lab.

It does no harm to other NOS distributions.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
