### PR TITLE
Redistribute loopback address on SONiC

### DIFF
--- a/cmd/internal/switcher/templates/test_data/dev/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/dev/sonic_frr.conf
@@ -55,6 +55,7 @@ router bgp 4200000010
  !
  address-family ipv4 unicast
   redistribute connected route-map DENY_MGMT
+  redistribute connected route-map LOOPBACKS
   neighbor FIREWALL allowas-in 2
   neighbor swp3 route-map fw-swp3-in in
  exit-address-family
@@ -133,6 +134,10 @@ route-map Vrf104001-in permit 10
  match ip address prefix-list Vrf104001-in-prefixes
 route-map Vrf104001-in6 permit 10
  match ipv6 address prefix-list Vrf104001-in6-prefixes
+!
+route-map LOOPBACKS permit 10
+ match interface Loopback0
+exit
 !
 route-map RM_SET_SRC permit 10
  set src 10.0.0.10

--- a/cmd/internal/switcher/templates/test_data/dev/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/dev/sonic_frr.conf
@@ -54,7 +54,6 @@ router bgp 4200000010
  neighbor swp3 interface peer-group FIREWALL
  !
  address-family ipv4 unicast
-  redistribute connected route-map DENY_MGMT
   redistribute connected route-map LOOPBACKS
   neighbor FIREWALL allowas-in 2
   neighbor swp3 route-map fw-swp3-in in

--- a/cmd/internal/switcher/templates/test_data/lab/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/lab/sonic_frr.conf
@@ -54,7 +54,6 @@ router bgp 4200000010
  neighbor swp3 interface peer-group FIREWALL
  !
  address-family ipv4 unicast
-  redistribute connected route-map DENY_MGMT
   redistribute connected route-map LOOPBACKS
   neighbor FIREWALL allowas-in 2
   neighbor swp3 route-map fw-swp3-in in

--- a/cmd/internal/switcher/templates/test_data/lab/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/lab/sonic_frr.conf
@@ -55,6 +55,7 @@ router bgp 4200000010
  !
  address-family ipv4 unicast
   redistribute connected route-map DENY_MGMT
+  redistribute connected route-map LOOPBACKS
   neighbor FIREWALL allowas-in 2
   neighbor swp3 route-map fw-swp3-in in
  exit-address-family
@@ -117,6 +118,10 @@ router bgp 4200000010 vrf Vrf104001
 ip prefix-list Vrf104001-in-prefixes permit 10.240.0.0/12 le 32
 route-map Vrf104001-in permit 10
  match ip address prefix-list Vrf104001-in-prefixes
+!
+route-map LOOPBACKS permit 10
+ match interface Loopback0
+exit
 !
 route-map RM_SET_SRC permit 10
  set src 10.0.0.10

--- a/cmd/internal/switcher/templates/test_data/notenants/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/notenants/sonic_frr.conf
@@ -37,7 +37,6 @@ router bgp 4200000010
  neighbor FIREWALL timers 2 8
  !
  address-family ipv4 unicast
-  redistribute connected route-map DENY_MGMT
   redistribute connected route-map LOOPBACKS
   neighbor FIREWALL allowas-in 2
  exit-address-family

--- a/cmd/internal/switcher/templates/test_data/notenants/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/notenants/sonic_frr.conf
@@ -38,6 +38,7 @@ router bgp 4200000010
  !
  address-family ipv4 unicast
   redistribute connected route-map DENY_MGMT
+  redistribute connected route-map LOOPBACKS
   neighbor FIREWALL allowas-in 2
  exit-address-family
  !
@@ -62,6 +63,10 @@ route-map DENY_MGMT deny 10
 route-map DENY_MGMT permit 20
 !
 ip route 0.0.0.0/0 192.168.0.254 nexthop-vrf mgmt
+!
+route-map LOOPBACKS permit 10
+ match interface Loopback0
+exit
 !
 route-map RM_SET_SRC permit 10
  set src 10.0.0.10

--- a/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
+++ b/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
@@ -60,6 +60,7 @@ router bgp {{ $ASN }}
  !
  address-family ipv4 unicast
   redistribute connected route-map DENY_MGMT
+  redistribute connected route-map LOOPBACKS
   neighbor FIREWALL allowas-in 2
   {{- range $k, $f := .Ports.Firewalls }}
   neighbor {{ $f.Port }} route-map fw-{{ $k }}-in in
@@ -164,6 +165,10 @@ route-map {{ .Name }} {{ .Policy }} {{ .Order }}
                 {{- end }}
         {{- end }}
 !{{- end }}{{- end }}
+route-map LOOPBACKS permit 10
+ match interface Loopback0
+exit
+!
 route-map RM_SET_SRC permit 10
  set src {{ .Loopback }}
 exit

--- a/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
+++ b/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
@@ -59,7 +59,6 @@ router bgp {{ $ASN }}
  {{- end }}
  !
  address-family ipv4 unicast
-  redistribute connected route-map DENY_MGMT
   redistribute connected route-map LOOPBACKS
   neighbor FIREWALL allowas-in 2
   {{- range $k, $f := .Ports.Firewalls }}


### PR DESCRIPTION
## Description

This adds the missing `redistribute` statement missing in https://github.com/metal-stack/metal-core/pull/159 to announce the loopback address via BGP. It is necessary to allow binding `eth0` to the management VRF without losing connectivity.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
