### PR TITLE
Revert "Set loopback as source address in SONiC frr.conf (#159)"

### DIFF
--- a/cmd/internal/switcher/templates/test_data/dev/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/dev/sonic_frr.conf
@@ -134,11 +134,5 @@ route-map Vrf104001-in permit 10
 route-map Vrf104001-in6 permit 10
  match ipv6 address prefix-list Vrf104001-in6-prefixes
 !
-route-map RM_SET_SRC permit 10
- set src 10.0.0.10
-exit
-!
-ip protocol bgp route-map RM_SET_SRC
-!
 line vty
 !

--- a/cmd/internal/switcher/templates/test_data/lab/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/lab/sonic_frr.conf
@@ -118,11 +118,5 @@ ip prefix-list Vrf104001-in-prefixes permit 10.240.0.0/12 le 32
 route-map Vrf104001-in permit 10
  match ip address prefix-list Vrf104001-in-prefixes
 !
-route-map RM_SET_SRC permit 10
- set src 10.0.0.10
-exit
-!
-ip protocol bgp route-map RM_SET_SRC
-!
 line vty
 !

--- a/cmd/internal/switcher/templates/test_data/notenants/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/notenants/sonic_frr.conf
@@ -63,11 +63,5 @@ route-map DENY_MGMT permit 20
 !
 ip route 0.0.0.0/0 192.168.0.254 nexthop-vrf mgmt
 !
-route-map RM_SET_SRC permit 10
- set src 10.0.0.10
-exit
-!
-ip protocol bgp route-map RM_SET_SRC
-!
 line vty
 !

--- a/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
+++ b/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
@@ -164,11 +164,5 @@ route-map {{ .Name }} {{ .Policy }} {{ .Order }}
                 {{- end }}
         {{- end }}
 !{{- end }}{{- end }}
-route-map RM_SET_SRC permit 10
- set src {{ .Loopback }}
-exit
-!
-ip protocol bgp route-map RM_SET_SRC
-!
 line vty
 !


### PR DESCRIPTION
This reverts commit c8e8098742758e77258688c3535ec88d81b3ec6e.

## Description

#159 was merged based on the assumption that it had already been tested which it wasn't. Rolling out the release caused several issues so I'm reverting the commit and will open a new PR for testing.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
