### PR TITLE
Add flag to enable setting loopback as default src

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	ApiPort                   int           `required:"false" default:"8080" desc:"set metal api port" envconfig:"metal_api_port"`
 	ApiBasePath               string        `required:"false" default:"" desc:"set metal api basepath" envconfig:"metal_api_basepath"`
 	LoopbackIP                string        `required:"false" default:"10.0.0.11" desc:"set the loopback ip address that is used with BGP unnumbered" split_words:"true"`
+	SetSrcLoopback            bool          `required:"false" default:"false" desc:"if true the loopback address will be used as default source address in frr.conf" split_words:"true"`
 	ASN                       string        `required:"false" default:"420000011" desc:"set the ASN that is used with BGP"`
 	SpineUplinks              []string      `required:"false" default:"swp31,swp32" desc:"set the ports that are connected to spines" envconfig:"spine_uplinks"`
 	ManagementGateway         string        `required:"false" default:"" desc:"the default gateway for the management network" split_words:"true"`

--- a/cmd/internal/core/core.go
+++ b/cmd/internal/core/core.go
@@ -23,6 +23,7 @@ type Core struct {
 	additionalBridgePorts   []string
 	additionalBridgeVIDs    []string
 	spineUplinks            []string
+	setSrcLoopback          bool
 
 	nos switcher.NOS
 
@@ -50,6 +51,7 @@ type Config struct {
 	AdditionalBridgePorts []string
 	AdditionalBridgeVIDs  []string
 	SpineUplinks          []string
+	SetSrcLoopback        bool
 
 	NOS switcher.NOS
 
@@ -77,6 +79,7 @@ func New(c Config) *Core {
 		additionalBridgePorts:   c.AdditionalBridgePorts,
 		additionalBridgeVIDs:    c.AdditionalBridgeVIDs,
 		spineUplinks:            c.SpineUplinks,
+		setSrcLoopback:          c.SetSrcLoopback,
 		nos:                     c.NOS,
 		driver:                  c.Driver,
 		eventServiceClient:      c.EventServiceClient,

--- a/cmd/internal/core/reconfigure-switch.go
+++ b/cmd/internal/core/reconfigure-switch.go
@@ -153,6 +153,7 @@ func (c *Core) buildSwitcherConfig(s *models.V1SwitchResponse) (*types.Conf, err
 		MetalCoreCIDR:        c.cidr,
 		AdditionalBridgeVIDs: c.additionalBridgeVIDs,
 		PXEVlanID:            c.pxeVlanID,
+		SetSrcLoopback:       c.setSrcLoopback,
 	}
 
 	p := types.Ports{

--- a/cmd/internal/switcher/templates/test_data/dev/conf.yaml
+++ b/cmd/internal/switcher/templates/test_data/dev/conf.yaml
@@ -2,6 +2,7 @@
 name: leaf01
 loglevel: warnings
 loopback: 10.0.0.10
+setsrcloopback: true
 asn: 4200000010
 metalcorecidr: 10.255.255.2/24
 ports:

--- a/cmd/internal/switcher/templates/test_data/lab/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/lab/sonic_frr.conf
@@ -120,11 +120,5 @@ ip prefix-list Vrf104001-in-prefixes permit 10.240.0.0/12 le 32
 route-map Vrf104001-in permit 10
  match ip address prefix-list Vrf104001-in-prefixes
 !
-route-map RM_SET_SRC permit 10
- set src 10.0.0.10
-exit
-!
-ip protocol bgp route-map RM_SET_SRC
-!
 line vty
 !

--- a/cmd/internal/switcher/templates/test_data/notenants/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/notenants/sonic_frr.conf
@@ -65,11 +65,5 @@ route-map DENY_MGMT permit 20
 !
 ip route 0.0.0.0/0 192.168.0.254 nexthop-vrf mgmt
 !
-route-map RM_SET_SRC permit 10
- set src 10.0.0.10
-exit
-!
-ip protocol bgp route-map RM_SET_SRC
-!
 line vty
 !

--- a/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
+++ b/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
@@ -166,11 +166,13 @@ route-map {{ .Name }} {{ .Policy }} {{ .Order }}
                 {{- end }}
         {{- end }}
 !{{- end }}{{- end }}
+{{- if .SetSrcLoopback }}
 route-map RM_SET_SRC permit 10
  set src {{ .Loopback }}
 exit
 !
 ip protocol bgp route-map RM_SET_SRC
 !
+{{- end }}
 line vty
 !

--- a/cmd/internal/switcher/types/types.go
+++ b/cmd/internal/switcher/types/types.go
@@ -15,6 +15,7 @@ type Conf struct {
 	MetalCoreCIDR        string
 	AdditionalBridgeVIDs []string
 	PXEVlanID            uint16
+	SetSrcLoopback       bool
 }
 
 type Ports struct {


### PR DESCRIPTION
## Description

Sometimes the loopback address can't be used as source address and setting it results in connectivity loss. For such cases I added a config parameter to enable or disable the feature.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
