### PR TITLE
Support additional routes to the management network gateway

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	ASN                       string        `required:"false" default:"420000011" desc:"set the ASN that is used with BGP"`
 	SpineUplinks              []string      `required:"false" default:"swp31,swp32" desc:"set the ports that are connected to spines" envconfig:"spine_uplinks"`
 	ManagementGateway         string        `required:"false" default:"" desc:"the default gateway for the management network" split_words:"true"`
+	AdditionalMgmtRoutes      []string      `required:"false" desc:"additional destination cidrs that are routed to the management network gateway, next to the default route" envconfig:"additional_mgmt_routes"`
 	ReconfigureSwitch         bool          `required:"false" default:"false" desc:"let metal-core reconfigure the switch" split_words:"true"`
 	ReconfigureSwitchInterval time.Duration `required:"false" default:"10s" desc:"pull interval to fetch and apply switch configuration" split_words:"true"`
 	Timeout                   time.Duration `required:"false" default:"15s" desc:"timeout for long lasting operations during switch registration and reconfiguration"`

--- a/cmd/internal/core/core.go
+++ b/cmd/internal/core/core.go
@@ -20,6 +20,7 @@ type Core struct {
 	rackID                  string
 	enableReconfigureSwitch bool
 	managementGateway       string
+	additionalMgmtRoutes    []string
 	additionalBridgePorts   []string
 	additionalBridgeVIDs    []string
 	spineUplinks            []string
@@ -48,6 +49,7 @@ type Config struct {
 	RackID                string
 	ReconfigureSwitch     bool
 	ManagementGateway     string
+	AdditionalMgmtRoutes  []string
 	AdditionalBridgePorts []string
 	AdditionalBridgeVIDs  []string
 	SpineUplinks          []string
@@ -76,6 +78,7 @@ func New(c Config) *Core {
 		rackID:                  c.RackID,
 		enableReconfigureSwitch: c.ReconfigureSwitch,
 		managementGateway:       c.ManagementGateway,
+		additionalMgmtRoutes:    c.AdditionalMgmtRoutes,
 		additionalBridgePorts:   c.AdditionalBridgePorts,
 		additionalBridgeVIDs:    c.AdditionalBridgeVIDs,
 		spineUplinks:            c.SpineUplinks,

--- a/cmd/internal/core/reconfigure-switch.go
+++ b/cmd/internal/core/reconfigure-switch.go
@@ -153,6 +153,7 @@ func (c *Core) buildSwitcherConfig(s *models.V1SwitchResponse) (*types.Conf, err
 		Loopback:             c.loopbackIP,
 		MetalCoreCIDR:        c.cidr,
 		AdditionalBridgeVIDs: c.additionalBridgeVIDs,
+		AdditionalMgmtRoutes: c.additionalMgmtRoutes,
 		PXEVlanID:            c.pxeVlanID,
 		SetSrcLoopback:       c.setSrcLoopback,
 	}

--- a/cmd/internal/switcher/templates/test_data/dev/conf.yaml
+++ b/cmd/internal/switcher/templates/test_data/dev/conf.yaml
@@ -5,6 +5,9 @@ loopback: 10.0.0.10
 setsrcloopback: true
 asn: 4200000010
 metalcorecidr: 10.255.255.2/24
+additionalmgmtroutes:
+  - 10.100.0.0/16
+  - 10.200.0.0/16
 ports:
   eth0:
     addresscidr: 192.168.101.12/24

--- a/cmd/internal/switcher/templates/test_data/dev/cumulus_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/dev/cumulus_frr.conf
@@ -84,6 +84,8 @@ route-map fw-swp3-vni permit 12
  match evpn vni 104010
 !
 ip route 0.0.0.0/0 192.168.101.1 nexthop-vrf mgmt
+ip route 10.100.0.0/16 192.168.101.1 nexthop-vrf mgmt
+ip route 10.200.0.0/16 192.168.101.1 nexthop-vrf mgmt
 !
 router bgp 4200000010 vrf vrf104001
  bgp router-id 10.0.0.10

--- a/cmd/internal/switcher/templates/test_data/dev/sonic_frr.conf
+++ b/cmd/internal/switcher/templates/test_data/dev/sonic_frr.conf
@@ -95,6 +95,8 @@ route-map fw-swp3-vni permit 12
  match evpn vni 104010
 !
 ip route 0.0.0.0/0 192.168.101.1 nexthop-vrf mgmt
+ip route 10.100.0.0/16 192.168.101.1 nexthop-vrf mgmt
+ip route 10.200.0.0/16 192.168.101.1 nexthop-vrf mgmt
 !
 router bgp 4200000010 vrf Vrf104001
  bgp router-id 10.0.0.10

--- a/cmd/internal/switcher/templates/tpl/cumulus_frr.tpl
+++ b/cmd/internal/switcher/templates/tpl/cumulus_frr.tpl
@@ -97,6 +97,9 @@ route-map {{ .Name }} {{ .Policy }} {{ .Order }}
 !
 {{- end }}
 ip route 0.0.0.0/0 {{ .Ports.Eth0.Gateway }} nexthop-vrf mgmt
+{{- range .AdditionalMgmtRoutes }}
+ip route {{ . }} {{ $.Ports.Eth0.Gateway }} nexthop-vrf mgmt
+{{- end }}
 !
 {{- range $vrf, $t := .Ports.Vrfs }}
 router bgp {{ $ASN }} vrf {{ $vrf }}

--- a/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
+++ b/cmd/internal/switcher/templates/tpl/sonic_frr.tpl
@@ -109,6 +109,9 @@ route-map {{ .Name }} {{ .Policy }} {{ .Order }}
 {{- end }}
 {{- if .Ports.Eth0.Gateway }}
 ip route 0.0.0.0/0 {{ .Ports.Eth0.Gateway }} nexthop-vrf mgmt
+{{- range .AdditionalMgmtRoutes }}
+ip route {{ . }} {{ $.Ports.Eth0.Gateway }} nexthop-vrf mgmt
+{{- end }}
 {{- end }}
 !
 {{- range $vrf, $t := .Ports.Vrfs }}

--- a/cmd/internal/switcher/types/types.go
+++ b/cmd/internal/switcher/types/types.go
@@ -14,6 +14,7 @@ type (
 		Ports                Ports
 		MetalCoreCIDR        string
 		AdditionalBridgeVIDs []string
+		AdditionalMgmtRoutes []string
 		PXEVlanID            uint16
 		SetSrcLoopback       bool
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	httppprof "net/http/pprof"
+	"net/netip"
 	"os"
 	"os/signal"
 	"strings"
@@ -49,6 +50,13 @@ func Run() {
 
 	log.Info("metal-core version", "version", v.V)
 	log.Info("configuration", "cfg", cfg)
+
+	for _, route := range cfg.AdditionalMgmtRoutes {
+		if _, err := netip.ParsePrefix(route); err != nil {
+			log.Error("invalid cidr in additional mgmt routes", "cidr", route, "error", err)
+			os.Exit(1)
+		}
+	}
 
 	driver, err := metalgo.NewDriver(
 		fmt.Sprintf("%s://%s:%d%s", cfg.ApiProtocol, cfg.ApiIP, cfg.ApiPort, cfg.ApiBasePath),
@@ -99,6 +107,7 @@ func Run() {
 		RackID:                cfg.RackID,
 		ReconfigureSwitch:     cfg.ReconfigureSwitch,
 		ManagementGateway:     cfg.ManagementGateway,
+		AdditionalMgmtRoutes:  cfg.AdditionalMgmtRoutes,
 		AdditionalBridgePorts: cfg.AdditionalBridgePorts,
 		AdditionalBridgeVIDs:  cfg.AdditionalBridgeVIDs,
 		SpineUplinks:          cfg.SpineUplinks,


### PR DESCRIPTION
The FRR templates render exactly one cross-VRF route towards the management network: the `ip route 0.0.0.0/0 <gw> nexthop-vrf mgmt` default derived from the eth0 gateway.

That is not enough when a leaf carries more-specific routes in its default VRF that shadow this default for management destinations. Concrete case: a partition co-located behind a shared internet exit announces /1 default-beaters into the leaf default VRF; those /1s are more specific than the /0, so traffic from services running in the default VRF (for example a PXE boot proxy on the switch) towards the management supernet is steered into the fabric exit instead of the management network. A more-specific static next to the /0 fixes it, but any externally added static is stripped again on metal-core's next frr.conf write. The only way out today is forking the whole template via `METAL_CORE_FRR_TPL_FILE`, which has to be re-synced with the stock template on every metal-core upgrade.

This PR adds `METAL_CORE_ADDITIONAL_MGMT_ROUTES`, a comma-separated list of destination CIDRs. Each entry is rendered as `ip route <cidr> <gw> nexthop-vrf mgmt` next to the existing default route, in both the SONiC and the Cumulus template. The CIDRs are validated at startup. When unset, the rendered output is unchanged.

We run this pattern in production on SONiC leaves (a co-located second partition reaching its management supernet past the exit's default-beaters, today via a forked template); happy to adjust naming or placement if you prefer a different shape.
