### PR TITLE
Apply the interface naming schema only once, when reporting nics

### DIFF
--- a/cmd/internal/switcher/sonic/sonic.go
+++ b/cmd/internal/switcher/sonic/sonic.go
@@ -153,11 +153,14 @@ func (s *Sonic) getPortsConfig(ctx context.Context) (map[string]PortInfo, error)
 		return nil, err
 	}
 
+	// keep the real interface names as keys; the naming schema is only applied
+	// when reporting nics to the metal-api. The keys are used to match the
+	// interface blacklist and to open the LLDP pcap handles, both of which
+	// need the actual netdev names.
 	portConfig := map[string]PortInfo{}
 	for _, p := range ports {
-		port := getPortByNamingSchema(p.Name, p.Alias, s.interfaceNamingSchema)
-		portConfig[port.Name] = PortInfo{
-			Alias: port.Alias,
+		portConfig[p.Name] = PortInfo{
+			Alias: p.Alias,
 		}
 	}
 


### PR DESCRIPTION
Targets #208 (branch `naming-schema-option`).

While adding the naming schema option in our SONiC setup (Edgecore AS7726-32X, Broadcom SONiC 4.5.2, native `intf_naming_mode`) I noticed the schema gets applied twice: `getPortsConfig` transforms the ports and keys the map by the transformed name, and `GetNics` then calls `getPortByNamingSchema` again on the already transformed values. That has three consequences:

- `swap` swaps twice in `GetNics` and ends up behaving exactly like `default`
- under `swap` and `alias` the interface blacklist (spine uplinks etc.) is compared against transformed map keys and no longer matches, so uplinks would get registered as machine nics
- `GetSwitchPorts` returns the transformed names, and `ConstantlyPhoneHome` opens one LLDP pcap client per returned name, so under `swap`/`alias` it would try to open netdevs like `Eth1/1` that do not exist on an `Ethernet0`-named system and machine liveness would silently break

This change keeps the port map keyed by the real interface names (blacklist matching and pcap handles need the actual netdevs) and applies the schema in one place only, when building the `V1SwitchNic` list for the metal-api.
